### PR TITLE
Make format key consistent for the weather plugin

### DIFF
--- a/src/plugin/weather.sh
+++ b/src/plugin/weather.sh
@@ -9,7 +9,7 @@ plugin_weather_accent_color_icon=$(get_tmux_option "@theme_plugin_weather_accent
 
 export plugin_weather_icon plugin_weather_accent_color plugin_weather_accent_color_icon
 
-plugin_weather_format_string=$(get_tmux_option "@theme_plugin_weather_format_string" "%t+H:%h")
+plugin_weather_format_string=$(get_tmux_option "@theme_plugin_weather_format" "%t+H:%h")
 
 function load_plugin() {
 	if ! command -v jq &>/dev/null; then


### PR DESCRIPTION
I'd like to propose a small adjustment to the `weather` plugin settings, so that it's set up like the `datetime` plugin. To illustrate the inconsistency, my current config looks something like this:

```
set -g @theme_plugin_datetime_format '%d/%m/%y %H:%M:%S'
set -g @theme_plugin_weather_format_string '%c%t'
``` 

References:

* https://github.com/fabioluciano/tmux-tokyo-night/blob/main/src/plugin/datetime.sh#L11
* https://github.com/fabioluciano/tmux-tokyo-night/blob/main/README.md#weather (already covered)