### PR TITLE
fix(battery): Colors / icons not updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,18 @@ Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch the plugin and source it. You can 
 
 ## Available Configurations
 
-| Configuration                       | Description                               | Avaliable Options                                            | Default            |
-| ----------------------------------- | ----------------------------------------- | ------------------------------------------------------------ | ------------------ |
-| `@theme_variation`                  | The tokyo night theme variation to be use | `night`, `storm`, `moon`                                     | `night`            |
-| `@theme_enable_icons`               | Switch icons in window list and plugins   | `1`, `0`                                                     | `1`                |
-| `@theme_active_pane_border_style`   |                                           |                                                              | `#737aa2`          |
-| `@theme_inactive_pane_border_style` |                                           |                                                              | `#292e42`          |
-| `@theme_left_separator`             |                                           |                                                              | ``                |
-| `@theme_right_separator`            |                                           |                                                              | ``                |
-| `@theme_window_with_activity_style` |                                           |                                                              | `italics`          |
-| `@theme_status_bell_style`          |                                           |                                                              | `bold`             |
-| `@theme_plugins`                    |                                           | `datetime`, `weather`, `playerctl`, `spt`, `homebrew`, `yay` | `datetime,weather` |
-| `@theme_disable_plugins`            | Disables plugins                          | `1`, `0`                                                     | `0`                |
+| Configuration                       | Description                               | Avaliable Options                                                       | Default            |
+| ----------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------- | ------------------ |
+| `@theme_variation`                  | The tokyo night theme variation to be use | `night`, `storm`, `moon`                                                | `night`            |
+| `@theme_enable_icons`               | Switch icons in window list and plugins   | `1`, `0`                                                                | `1`                |
+| `@theme_active_pane_border_style`   |                                           |                                                                         | `#737aa2`          |
+| `@theme_inactive_pane_border_style` |                                           |                                                                         | `#292e42`          |
+| `@theme_left_separator`             |                                           |                                                                         | ``                |
+| `@theme_right_separator`            |                                           |                                                                         | ``                |
+| `@theme_window_with_activity_style` |                                           |                                                                         | `italics`          |
+| `@theme_status_bell_style`          |                                           |                                                                         | `bold`             |
+| `@theme_plugins`                    |                                           | `datetime`, `weather`, `playerctl`, `spt`, `homebrew`, `yay`, `battery` | `datetime,weather` |
+| `@theme_disable_plugins`            | Disables plugins                          | `1`, `0`                                                                | `0`                |
 
 ## Plugins
 

--- a/src/plugin/battery.sh
+++ b/src/plugin/battery.sh
@@ -133,7 +133,7 @@ else
     if [ "$charging_status" ==  "charging" ] || [ "$charging_status" == "charged" ]; then
         plugin_battery_icon=$(get_tmux_option "@theme_plugin_battery_charging_icon" " ")
     else
-        plugin_battery_icon=$(get_tmux_option "@theme_plugin_battery_discharging_icon" "󰁹 ")
+        plugin_battery_icon=$(get_tmux_option "@theme_plugin_battery_discharging_icon" "󰁹")
     fi
 
     battery_number="${battery_percentage//%/}"

--- a/src/theme.sh
+++ b/src/theme.sh
@@ -86,7 +86,6 @@ if [ "$theme_disable_plugins" -ne 1 ]; then
 				accent_color_icon="${PALLETE[$accent_color_icon]}"
 			fi
 
-			separator_start="#[fg=${accent_color},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
 			separator_end="#[fg=${PALLETE[bg_highlight]},bg=${accent_color}]${right_separator}#[none]"
 			separator_icon_start="#[fg=${accent_color_icon},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
 			separator_icon_end="#[fg=${accent_color},bg=${accent_color_icon}]${right_separator}#[none]"

--- a/src/theme.sh
+++ b/src/theme.sh
@@ -78,24 +78,42 @@ if [ "$theme_disable_plugins" -ne 1 ]; then
 			accent_color="${!accent_color_var}"
 			accent_color_icon="${!accent_color_icon_var}"
 
-			separator_start="#[fg=${PALLETE[$accent_color]},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
-			separator_end="#[fg=${PALLETE[bg_highlight]},bg=${PALLETE[$accent_color]}]${right_separator}#[none]"
-			separator_icon_start="#[fg=${PALLETE[$accent_color_icon]},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
-			separator_icon_end="#[fg=${PALLETE[$accent_color]},bg=${PALLETE[$accent_color_icon]}]${right_separator}#[none]"
-
-			if [ "$plugin" == "datetime" ]; then
-				plugin_output="#[fg=${PALLETE[white]},bg=${PALLETE[$accent_color]}]${plugin_execution_string}#[none]"
-			else
-				plugin_output="#[fg=${PALLETE[white]},bg=${PALLETE[$accent_color]}]#($plugin_script_path)#[none]"
+			# For every plugin except battery, turn accent_color and accent_color_icon into
+			# the colors from the palette. The battery plugin uses placeholders so it can
+			# change the color based on battery level
+			if [ "$plugin" != "battery" ]; then
+				accent_color="${PALLETE[$accent_color]}"
+				accent_color_icon="${PALLETE[$accent_color_icon]}"
 			fi
+
+			separator_start="#[fg=${accent_color},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
+			separator_end="#[fg=${PALLETE[bg_highlight]},bg=${accent_color}]${right_separator}#[none]"
+			separator_icon_start="#[fg=${accent_color_icon},bg=${PALLETE[bg_highlight]}]${right_separator}#[none]"
+			separator_icon_end="#[fg=${accent_color},bg=${accent_color_icon}]${right_separator}#[none]"
+
 			plugin_output_string=""
 
-			plugin_icon_output="${separator_icon_start}#[fg=${PALLETE[white]},bg=${PALLETE[$accent_color_icon]}]${plugin_icon}${separator_icon_end}"
+			# For datetime and battery, we run the plugin to get the content
+			# For battery, the content is actually a template that will be replaced when
+			# running the script later
+			if [ "$plugin" == "datetime" ] || [ "$plugin" == "battery" ]; then
+				plugin_output="#[fg=${PALLETE[white]},bg=${accent_color}]${plugin_execution_string}#[none]"
+			else
+				plugin_output="#[fg=${PALLETE[white]},bg=${accent_color}]#($plugin_script_path)#[none]"
+			fi
+
+			plugin_icon_output="${separator_icon_start}#[fg=${PALLETE[white]},bg=${accent_color_icon}]${plugin_icon}${separator_icon_end}"
 
 			if [ ! $is_last_plugin -eq 1 ] && [ "${#plugins[@]}" -gt 1 ]; then
 				plugin_output_string="${plugin_icon_output}${plugin_output} ${separator_end}"
 			else
 				plugin_output_string="${plugin_icon_output}${plugin_output} "
+			fi
+
+			# For the battery plugin, we pass $plugin_output_string as an argument to the script so 
+			# we can dynamically change the icon and accent colors
+			if [ "$plugin" == "battery" ]; then
+				plugin_output_string="#($plugin_script_path \"$plugin_output_string\")"
 			fi
 
 			tmux set-option -ga status-right "$plugin_output_string"


### PR DESCRIPTION
I didn't understand that theme.sh is only run once when configuring the tmux status line (it worked fine when I forced refreshed my config but not without the config reloads). As a result, the icon and colors for the battery plugin were static and didn't update based on state as it changed.

To fix that, I had to set some placeholders and pass the whole section of the battery plugin as a template to the plugin itself so it could set the icon/colors dynamically, based on the state. It's not the cleanest but I didn't want to have to duplicate all of the separator / ordering logic so felt like this was the best approach.