### PR TITLE
fix: shellcheck warnings and extra space on active window tab

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,3 +16,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        with:
+          check_together: "yes"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize]
 
 name: "Trigger: Push action"
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch the plugin and source it. You can 
 | Configuration                       | Description                               | Avaliable Options                                                       | Default            |
 | ----------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------- | ------------------ |
 | `@theme_variation`                  | The tokyo night theme variation to be use | `night`, `storm`, `moon`                                                | `night`            |
-| `@theme_enable_icons`               | Switch icons in window list and plugins   | `1`, `0`                                                                | `1`                |
 | `@theme_active_pane_border_style`   |                                           |                                                                         | `#737aa2`          |
 | `@theme_inactive_pane_border_style` |                                           |                                                                         | `#292e42`          |
 | `@theme_left_separator`             |                                           |                                                                         | ``                |
@@ -162,8 +161,6 @@ set -g @theme_transparent_right_separator_inverse ''
 ```
 
 ![Screenshot 2024-09-07 at 12 39 35](https://github.com/user-attachments/assets/a33417b1-34e0-4212-952e-7ef1e240e943)
-
-
 
 [features]: #features
 [screenshots]: #screenshots

--- a/src/plugin/datetime.sh
+++ b/src/plugin/datetime.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 # shellcheck disable=SC2005

--- a/src/plugin/homebrew.sh
+++ b/src/plugin/homebrew.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 # shellcheck disable=SC2005

--- a/src/plugin/playerctl.sh
+++ b/src/plugin/playerctl.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 #

--- a/src/plugin/spt.sh
+++ b/src/plugin/spt.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 #

--- a/src/plugin/weather.sh
+++ b/src/plugin/weather.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 # shellcheck disable=SC2005
@@ -17,7 +19,7 @@ function load_plugin() {
 	fi
 
 	LOCATION=$(curl -s http://ip-api.com/json | jq -r '"\(.city), \(.country)"' 2>/dev/null)
-	WEATHER=$(curl -sL wttr.in/${LOCATION// /%20}\?format="${plugin_weather_format_string}" 2>/dev/null)
+	WEATHER=$(curl -sL wttr.in/"${LOCATION// /%20}"\?format="${plugin_weather_format_string}" 2>/dev/null)
 
 	echo "${WEATHER}"
 }

--- a/src/plugin/yay.sh
+++ b/src/plugin/yay.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=src/utils.sh
 . "$ROOT_DIR/../utils.sh"
 
 # shellcheck disable=SC2005

--- a/src/theme.sh
+++ b/src/theme.sh
@@ -17,12 +17,10 @@ theme_disable_plugins=$(get_tmux_option "@theme_disable_plugins" 0)
 ### Load Options
 border_style_active_pane=$(get_tmux_option "@theme_active_pane_border_style" "${PALLETE['dark5']}")
 border_style_inactive_pane=$(get_tmux_option "@theme_inactive_pane_border_style" "${PALLETE[bg_highlight]}")
-left_separator=$(get_tmux_option "@theme_left_separator" "")
 right_separator=$(get_tmux_option "@theme_right_separator" "")
 transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
 
 if [ "$transparent" = "true" ]; then
-	left_separator_inverse=$(get_tmux_option "@theme_transparent_left_separator_inverse" "")
 	right_separator_inverse=$(get_tmux_option "@theme_transparent_right_separator_inverse" "")
 fi
 

--- a/src/theme.sh
+++ b/src/theme.sh
@@ -75,9 +75,9 @@ if [ "$theme_disable_plugins" -ne 1 ]; then
 				is_last_plugin=1
 			fi
 
-			# shellcheck source=src/plugin/datetime.sh
 			plugin_script_path="${CURRENT_DIR}/plugin/${plugin}.sh"
 			plugin_execution_string="$(${plugin_script_path})"
+			# shellcheck source=src/plugin/datetime.sh
 			. "$plugin_script_path"
 
 			icon_var="plugin_${plugin}_icon"

--- a/src/theme.sh
+++ b/src/theme.sh
@@ -8,7 +8,6 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$CURRENT_DIR/utils.sh"
 
 theme_variation=$(get_tmux_option "@theme_variation" "night")
-theme_enable_icons=$(get_tmux_option "@theme_enable_icons" 1)
 theme_disable_plugins=$(get_tmux_option "@theme_disable_plugins" 0)
 
 # shellcheck source=src/palletes/night.sh

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -15,6 +15,7 @@ function get_tmux_option() {
 function generate_left_side_string() {
 
 	session_icon=$(get_tmux_option "@theme_session_icon" "⋅")
+	left_separator=$(get_tmux_option "@theme_left_separator" "")
 	transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
 
 	if [ "$transparent" = "true" ]; then
@@ -30,6 +31,7 @@ function generate_inactive_window_string() {
 
 	inactive_window_icon=$(get_tmux_option "@theme_plugin_inactive_window_icon" " ")
 	zoomed_window_icon=$(get_tmux_option "@theme_plugin_zoomed_window_icon" " ")
+	left_separator=$(get_tmux_option "@theme_left_separator" "")
 	transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
 
 	if [ "$transparent" = "true" ]; then
@@ -52,6 +54,7 @@ function generate_active_window_string() {
 	active_window_icon=$(get_tmux_option "@theme_plugin_active_window_icon" " ")
 	zoomed_window_icon=$(get_tmux_option "@theme_plugin_zoomed_window_icon" " ")
 	pane_synchronized_icon=$(get_tmux_option "@theme_plugin_pane_synchronized_icon" "✵")
+	left_separator=$(get_tmux_option "@theme_left_separator" "")
 
 	if [ "$transparent" = "true" ]; then
 		separator_start="#[bg=default,fg=${PALLETE['magenta']}]${left_separator_inverse}#[bg=${PALLETE['magenta']},fg=${PALLETE['bg_highlight']}]"

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -15,6 +15,8 @@ function get_tmux_option() {
 function generate_left_side_string() {
 
 	session_icon=$(get_tmux_option "@theme_session_icon" "⋅")
+	transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
+
 	if [ "$transparent" = "true" ]; then
 		local separator_end="#[bg=default]#{?client_prefix,#[fg=${PALLETE[yellow]}],#[fg=${PALLETE[green]}]}${left_separator:?}#[none]"
 	else
@@ -28,8 +30,11 @@ function generate_inactive_window_string() {
 
 	inactive_window_icon=$(get_tmux_option "@theme_plugin_inactive_window_icon" " ")
 	zoomed_window_icon=$(get_tmux_option "@theme_plugin_zoomed_window_icon" " ")
+	transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
 
 	if [ "$transparent" = "true" ]; then
+		left_separator_inverse=$(get_tmux_option "@theme_transparent_left_separator_inverse" "")
+
 		local separator_start="#[bg=default,fg=${PALLETE['dark5']}]${left_separator_inverse}#[bg=${PALLETE['dark5']},fg=${PALLETE['bg_highlight']}]"
 		local separator_internal="#[bg=${PALLETE['dark3']},fg=${PALLETE['dark5']}]${left_separator:?}#[none]"
 		local separator_end="#[bg=default,fg=${PALLETE['dark3']}]${left_separator:?}#[none]"

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -55,8 +55,11 @@ function generate_active_window_string() {
 	zoomed_window_icon=$(get_tmux_option "@theme_plugin_zoomed_window_icon" " ")
 	pane_synchronized_icon=$(get_tmux_option "@theme_plugin_pane_synchronized_icon" "✵")
 	left_separator=$(get_tmux_option "@theme_left_separator" "")
+	transparent=$(get_tmux_option "@theme_transparent_status_bar" "false")
 
 	if [ "$transparent" = "true" ]; then
+		left_separator_inverse=$(get_tmux_option "@theme_transparent_left_separator_inverse" "")
+		
 		separator_start="#[bg=default,fg=${PALLETE['magenta']}]${left_separator_inverse}#[bg=${PALLETE['magenta']},fg=${PALLETE['bg_highlight']}]"
 		separator_internal="#[bg=${PALLETE['purple']},fg=${PALLETE['magenta']}]${left_separator:?}#[none]"
 		separator_end="#[bg=default,fg=${PALLETE['purple']}]${left_separator:?}#[none]"

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -69,5 +69,5 @@ function generate_active_window_string() {
 		separator_end="#[bg=${PALLETE[bg_highlight]},fg=${PALLETE['purple']}]${left_separator:?}#[none]"
 	fi
 
-	echo "${separator_start}#[fg=${PALLETE[white]}]#I${separator_internal}#[fg=${PALLETE[white]}] #{?window_zoomed_flag,$zoomed_window_icon,$active_window_icon}#W #{?pane_synchronized,$pane_synchronized_icon, }${separator_end}#[none]"
+	echo "${separator_start}#[fg=${PALLETE[white]}]#I${separator_internal}#[fg=${PALLETE[white]}] #{?window_zoomed_flag,$zoomed_window_icon,$active_window_icon}#W #{?pane_synchronized,$pane_synchronized_icon,}${separator_end}#[none]"
 }


### PR DESCRIPTION
Not urgent, just noticed the shellcheck errors (a bunch of which i caused) so decided to clean them up.

Also fixing extra space in the active window, so that active and inactive windows tabs are the same size so it's not jarring when changing tabs. If there's a window where the panes are synchronized, that window tab will still be one larger when active due to the additional icon but that seems fine.