### PR TITLE
feat(weather): add support for overriding IP-based location

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch the plugin and source it. You can 
 
 | Configuration                              | Description | Avaliable Options | Default |
 | ------------------------------------------ | ----------- | ----------------- | ------- |
-| `@theme_plugin_datetime_icon`              |             |                   |         |
+| `@theme_plugin_datetime_icon`              |             | Any character 📅  | Nerd Font 'Calendar' icon        |
 | `@theme_plugin_datetime_accent_color`      |             |                   |         |
 | `@theme_plugin_datetime_accent_color_icon` |             |                   |         |
 | `@theme_plugin_datetime_format`            |             |                   |         |
@@ -80,10 +80,16 @@ Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch the plugin and source it. You can 
 
 | Configuration                             | Description | Avaliable Options | Default |
 | ----------------------------------------- | ----------- | ----------------- | ------- |
-| `@theme_plugin_weather_icon`              |             |                   |         |
+| `@theme_plugin_weather_icon`              |             | Any character 🌡️  |  Font Awesome 'Cloud' icon        |
 | `@theme_plugin_weather_accent_color`      |             |                   |         |
 | `@theme_plugin_weather_accent_color_icon` |             |                   |         |
-| `@theme_plugin_weather_format`            |             |                   |         |
+| `@theme_plugin_weather_format`            | Format for displaying weather information | `%t`, `%c`, `%h`, `%w` (temperature, condition, humidity, wind) | `%t+H:%h` |
+| `@theme_plugin_weather_location`          | Location for weather (city/country)   | `"City, Country"`  | IP-based location detection |
+
+#### Example
+  ```
+  set -g @theme_plugin_weather_location 'Blacksburg, United States'
+  ```
 
 ### Playerctl
 

--- a/src/plugin/weather.sh
+++ b/src/plugin/weather.sh
@@ -8,6 +8,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 plugin_weather_icon=$(get_tmux_option "@theme_plugin_weather_icon" " ")
 plugin_weather_accent_color=$(get_tmux_option "@theme_plugin_weather_accent_color" "blue7")
 plugin_weather_accent_color_icon=$(get_tmux_option "@theme_plugin_weather_accent_color_icon" "blue0")
+plugin_weather_location=$(get_tmux_option "@theme_plugin_weather_location" "")
 
 export plugin_weather_icon plugin_weather_accent_color plugin_weather_accent_color_icon
 
@@ -18,8 +19,13 @@ function load_plugin() {
 		exit 1
 	fi
 
-	LOCATION=$(curl -s http://ip-api.com/json | jq -r '"\(.city), \(.country)"' 2>/dev/null)
-	WEATHER=$(curl -sL wttr.in/"${LOCATION// /%20}"\?format="${plugin_weather_format_string}" 2>/dev/null)
+    if [[ -n "$plugin_weather_location" ]]; then
+        LOCATION="$plugin_weather_location"
+    else
+        LOCATION=$(curl -s http://ip-api.com/json | jq -r '"\(.city), \(.country)"' 2>/dev/null)
+    fi
+
+    WEATHER=$(curl -sL wttr.in/"${LOCATION// /%20}"\?format="${plugin_weather_format_string}" 2>/dev/null)
 
 	echo "${WEATHER}"
 }


### PR DESCRIPTION
- Added a configuration option `@theme_plugin_weather_location` to set a specific location (e.g., city, country) for weather instead of using IP-based detection.
- Updated `weather.sh` to handle the new configuration, including fallback to IP-based location if the option is not set.
- Documented the new configuration in the README with examples for city and ZIP code usage.
- Performed minor cleanup in the README for consistency and clarity.