### PR TITLE
feat(playerctl): add ability to ignore players

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Hit <kbd>prefix</kbd> + <kbd>I</kbd> to fetch the plugin and source it. You can 
 | `@theme_plugin_playerctl_accent_color`      |             |                   |         |
 | `@theme_plugin_playerctl_accent_color_icon` |             |                   |         |
 | `@theme_plugin_playerctl_format`            |             |                   |         |
+| `@theme_plugin_playerctl_ignore_players`    | List of players to ignore | `"player1,player2,.."` | `"IGNORE"` |
 
 ### Battery
 

--- a/src/plugin/playerctl.sh
+++ b/src/plugin/playerctl.sh
@@ -11,6 +11,7 @@ plugin_playerctl_accent_color=$(get_tmux_option "@theme_plugin_playerctl_accent_
 plugin_playerctl_accent_color_icon=$(get_tmux_option "@theme_plugin_playerctl_accent_color_icon" "blue0")
 
 plugin_playerctl_format_string=$(get_tmux_option "@theme_plugin_playerctl_format_string" "{{artist}} - {{title}}")
+plugin_playerctl_ignore_players=$(get_tmux_option "@theme_plugin_playerctl_ignore_players" "IGNORE")
 
 export plugin_playerctl_icon plugin_playerctl_accent_color plugin_playerctl_accent_color_icon
 
@@ -19,8 +20,8 @@ function load_plugin() {
 		exit 1
 	fi
 
-	if [[ $(playerctl status) == "Playing" ]]; then
-		playerctl=$(playerctl metadata --format "$plugin_playerctl_format_string")
+	if [[ $(playerctl status -i "$plugin_playerctl_ignore_players") == "Playing" ]]; then
+		playerctl=$(playerctl metadata -i "$plugin_playerctl_ignore_players" --format "$plugin_playerctl_format_string")
 		echo "${playerctl}"
 	else
 		echo "Not Playing"


### PR DESCRIPTION
- Added a configuration option `@theme_plugin_playerctl_ignore_players` to list the players that should be ignored.
- Updated `playerctl.sh` to handle the new configuration, including fallback to a placeholder value `"IGNORE"` if the option is not set.
- Documented the new configuration in the README with syntax for listing players to be ignored.